### PR TITLE
Add LinkedIn pattern & allow percent encoded characters in profile id

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export interface Score {
   score: number;
 }
 
-const PROFILE_ID = '[A-Za-z0-9_\\-\\.]+';
+const PROFILE_ID = '[A-Za-z0-9_\\-\\.%]+';
 const QUERY_PARAM = '(\\?.*)?';
 
 const createRegexp = (profileMatch: ProfileMatch, config: Config): RegExp => {

--- a/src/profiles/linkedin.spec.ts
+++ b/src/profiles/linkedin.spec.ts
@@ -8,14 +8,16 @@ describe('PROFILE: linkedin', () => {
     sl = new SocialLinks();
   });
 
-  const testProfile = (profile: string, profileId: string, desktop: string, mobile: string) => {
+  const testProfile = (profile: string, profileId: string, desktop: string, mobile: string, company: string) => {
     expect(sl.hasProfile(profile)).toBeTruthy();
 
     expect(sl.isValid(profile, desktop)).toBeTruthy();
     expect(sl.isValid(profile, mobile)).toBeTruthy();
+    expect(sl.isValid(profile, company)).toBeTruthy();
 
     expect(sl.getProfileId(profile, desktop)).toBe(profileId);
     expect(sl.getProfileId(profile, mobile)).toBe(profileId);
+    expect(sl.getProfileId(profile, company)).toBe(profileId);
 
     expect(sl.getLink(profile, profileId)).toBe(desktop);
     expect(sl.getLink(profile, profileId, TYPE_DESKTOP)).toBe(desktop);
@@ -24,6 +26,7 @@ describe('PROFILE: linkedin', () => {
     expect(sl.sanitize(profile, desktop)).toBe(desktop);
     expect(sl.sanitize(profile, desktop, TYPE_DESKTOP)).toBe(desktop);
     expect(sl.sanitize(profile, mobile, TYPE_MOBILE)).toBe(mobile);
+    expect(sl.sanitize(profile, company, TYPE_DESKTOP)).toBe(desktop);
   };
 
   const testProfileDesktop = (profile: string, profileId: string, desktop: string) => {
@@ -45,7 +48,8 @@ describe('PROFILE: linkedin', () => {
     const profileId = 'gkucmierz';
     const desktop = `https://linkedin.com/in/${profileId}`;
     const mobile = `https://linkedin.com/mwlite/in/${profileId}`;
-    testProfile(profile, profileId, desktop, mobile);
+    const company = `https://linkedin.com/company/${profileId}`;
+    testProfile(profile, profileId, desktop, mobile, company);
   });
 
   it('should accept localized urls', () => {
@@ -55,4 +59,12 @@ describe('PROFILE: linkedin', () => {
     expect(sl.sanitize(profile, 'https://de.linkedin.com/in/anton-begehr/')).toBe('https://linkedin.com/in/anton-begehr');
     expect(sl.sanitize(profile, 'https://de.linkedin.com/mwlite/in/anton-begehr/', TYPE_MOBILE)).toBe('https://linkedin.com/mwlite/in/anton-begehr');
   });
+
+  it('should capture a profile id that contains percent encoded characters', () => {
+    const profile = 'linkedin';
+    const profileId = 'gk%5Fucmierz';
+    const companyUrlBase = `https://linkedin.com/company/${profileId}`;
+    expect(sl.isValid(profile, companyUrlBase)).toBeTruthy()
+    expect(sl.getProfileId(profile, companyUrlBase)).toBe(profileId)
+   })
 });

--- a/src/profiles/linkedin.ts
+++ b/src/profiles/linkedin.ts
@@ -13,5 +13,11 @@ export const linkedin = {
       pattern: 'https://linkedin.com/mwlite/in/{PROFILE_ID}'
     },
     { match: '({PROFILE_ID})', group: 1 },
+    {
+			match: '(https?://)?([a-z]{2,3}.)?linkedin.com/company/({PROFILE_ID})/?',
+			group: 3,
+			type: TYPE_DESKTOP,
+			pattern: 'https://linkedin.com/company/{PROFILE_ID}',
+		}
   ]
 };


### PR DESCRIPTION
Added regex for the `linkedin.com/company/XXXXXXX`

Updated `PROFILE_ID` regex to allow percent encoded characters from the url. (Example URL: `https://www.linkedin.com/company/brigham-and-women%27s-hospital/`)