### PR TITLE
Strict mode & fix YouTube regex

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export interface Score {
   score: number;
 }
 
-const PROFILE_ID = '[A-Za-z0-9_\\-\\.]+';
+const PROFILE_ID = '[A-Za-z0-9_\\-\\.%]+';
 const QUERY_PARAM = '(\\?.*)?';
 
 const createRegexp = (profileMatch: ProfileMatch, config: Config): RegExp => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ const PROFILE_ID = '[A-Za-z0-9_\\-\\.%]+';
 const QUERY_PARAM = '(\\?.*)?';
 
 const createRegexp = (profileMatch: ProfileMatch, config: Config): RegExp => {
-  const str = profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`);
+  const str = config.strict ? profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`) :profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`).replace(/\/\?/, '/.*')
+
   const isTyped = typeof profileMatch.type !== 'undefined';
   const regexp = new RegExp([
     '^', str, ...(config.allowQueryParams && isTyped ? [QUERY_PARAM] : []), '$'
@@ -45,12 +46,14 @@ export interface Config {
   usePredefinedProfiles?: boolean;
   trimInput?: boolean;
   allowQueryParams?: boolean;
+  strict?: boolean;
 }
 
 export const DEFAULT_CONFIG: Config = {
   usePredefinedProfiles: true,
   trimInput: true,
   allowQueryParams: false,
+  strict: true
 };
 
 export class SocialLinks {

--- a/src/profiles/linkedin.spec.ts
+++ b/src/profiles/linkedin.spec.ts
@@ -8,14 +8,16 @@ describe('PROFILE: linkedin', () => {
     sl = new SocialLinks();
   });
 
-  const testProfile = (profile: string, profileId: string, desktop: string, mobile: string) => {
+  const testProfile = (profile: string, profileId: string, desktop: string, mobile: string, company: string) => {
     expect(sl.hasProfile(profile)).toBeTruthy();
 
     expect(sl.isValid(profile, desktop)).toBeTruthy();
     expect(sl.isValid(profile, mobile)).toBeTruthy();
+    expect(sl.isValid(profile, company)).toBeTruthy();
 
     expect(sl.getProfileId(profile, desktop)).toBe(profileId);
     expect(sl.getProfileId(profile, mobile)).toBe(profileId);
+    expect(sl.getProfileId(profile, company)).toBe(profileId);
 
     expect(sl.getLink(profile, profileId)).toBe(desktop);
     expect(sl.getLink(profile, profileId, TYPE_DESKTOP)).toBe(desktop);
@@ -24,6 +26,7 @@ describe('PROFILE: linkedin', () => {
     expect(sl.sanitize(profile, desktop)).toBe(desktop);
     expect(sl.sanitize(profile, desktop, TYPE_DESKTOP)).toBe(desktop);
     expect(sl.sanitize(profile, mobile, TYPE_MOBILE)).toBe(mobile);
+    expect(sl.sanitize(profile, company, TYPE_DESKTOP)).toBe(desktop);
   };
 
   const testProfileDesktop = (profile: string, profileId: string, desktop: string) => {
@@ -45,7 +48,8 @@ describe('PROFILE: linkedin', () => {
     const profileId = 'gkucmierz';
     const desktop = `https://linkedin.com/in/${profileId}`;
     const mobile = `https://linkedin.com/mwlite/in/${profileId}`;
-    testProfile(profile, profileId, desktop, mobile);
+    const company = `https://linkedin.com/company/${profileId}`;
+    testProfile(profile, profileId, desktop, mobile, company);
   });
 
   it('should accept localized urls', () => {
@@ -55,4 +59,12 @@ describe('PROFILE: linkedin', () => {
     expect(sl.sanitize(profile, 'https://de.linkedin.com/in/anton-begehr/')).toBe('https://linkedin.com/in/anton-begehr');
     expect(sl.sanitize(profile, 'https://de.linkedin.com/mwlite/in/anton-begehr/', TYPE_MOBILE)).toBe('https://linkedin.com/mwlite/in/anton-begehr');
   });
+
+  it('should capture a profile id that contains percent encoded characters', () => {
+    const profile = 'linkedin';
+    const profileId = 'gk%5Fucmierz';
+    const companyUrlBase = `https://linkedin.com/company/${profileId}`;
+    expect(sl.isValid(profile, companyUrlBase)).toBeTruthy()
+    expect(sl.getProfileId(profile, companyUrlBase)).toBe(profileId)
+   })
 });

--- a/src/profiles/linkedin.ts
+++ b/src/profiles/linkedin.ts
@@ -13,5 +13,11 @@ export const linkedin = {
       pattern: 'https://linkedin.com/mwlite/in/{PROFILE_ID}'
     },
     { match: '({PROFILE_ID})', group: 1 },
+    {
+			match: '(https?://)?([a-z]{2,3}.)?linkedin.com/company/({PROFILE_ID})/?',
+			group: 3,
+			type: TYPE_DESKTOP,
+			pattern: 'https://linkedin.com/company/{PROFILE_ID}',
+		}
   ]
 };

--- a/src/profiles/youtube.spec.ts
+++ b/src/profiles/youtube.spec.ts
@@ -3,9 +3,11 @@ import { SocialLinks, TYPE_DESKTOP, TYPE_MOBILE } from '../main';
 
 describe('PROFILE: youtube', () => {
   let sl: SocialLinks;
+  let lax_sl: SocialLinks;
 
   beforeEach(() => {
     sl = new SocialLinks();
+    lax_sl = new SocialLinks({ strict: false });
   });
 
   const testProfile = (profile: string, profileId: string, given: string, expected: string) => {
@@ -35,4 +37,14 @@ describe('PROFILE: youtube', () => {
 
     old.map(url => testProfile(profile, profileId, url, curr));
   });
+
+  it('can parse less strictly', () => {
+  const profile = 'youtube';
+    const profileId = 'gkucmierz';
+
+    const expectedUrl = `https://youtube.com/@${profileId}`;
+    const urlWithExtras = `https://youtube.com/user/${profileId}/videos`;
+
+    expect(lax_sl.sanitize(profile, urlWithExtras)).toBe(expectedUrl);
+  })
 });

--- a/src/profiles/youtube.ts
+++ b/src/profiles/youtube.ts
@@ -5,7 +5,7 @@ export const youtube =  {
   name: 'youtube',
   matches: [
     {
-      match: '(https?://)?(www.)?youtube.com/@?({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
+      match: '(https?://)?(www.)?youtube.com/@({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
       pattern: 'https://youtube.com/@{PROFILE_ID}'
     },
     {


### PR DESCRIPTION
- Added config option for `strict` with a default value of `true`. Setting this to `false` will allow the end of the url to be anything. Useful for YouTube links that are suffixed with `/videos`

- Updated YouTube regex to require `@` instead of letting it be optional. This was incorrectly returning `user` as the profile id when the url was `youtube.com/user/XXXXXXX`