### PR TITLE
Strict mode & YouTube regex fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ const PROFILE_ID = '[A-Za-z0-9_\\-\\.]+';
 const QUERY_PARAM = '(\\?.*)?';
 
 const createRegexp = (profileMatch: ProfileMatch, config: Config): RegExp => {
-  const str = profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`);
+  const str = config.strict ? profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`) :profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`).replace(/\/\?/, '/.*')
+
   const isTyped = typeof profileMatch.type !== 'undefined';
   const regexp = new RegExp([
     '^', str, ...(config.allowQueryParams && isTyped ? [QUERY_PARAM] : []), '$'
@@ -45,12 +46,14 @@ export interface Config {
   usePredefinedProfiles?: boolean;
   trimInput?: boolean;
   allowQueryParams?: boolean;
+  strict?: boolean;
 }
 
 export const DEFAULT_CONFIG: Config = {
   usePredefinedProfiles: true,
   trimInput: true,
   allowQueryParams: false,
+  strict: true
 };
 
 export class SocialLinks {

--- a/src/profiles/youtube.spec.ts
+++ b/src/profiles/youtube.spec.ts
@@ -3,9 +3,11 @@ import { SocialLinks, TYPE_DESKTOP, TYPE_MOBILE } from '../main';
 
 describe('PROFILE: youtube', () => {
   let sl: SocialLinks;
+  let lax_sl: SocialLinks;
 
   beforeEach(() => {
     sl = new SocialLinks();
+    lax_sl = new SocialLinks({ strict: false });
   });
 
   const testProfile = (profile: string, profileId: string, given: string, expected: string) => {
@@ -35,4 +37,14 @@ describe('PROFILE: youtube', () => {
 
     old.map(url => testProfile(profile, profileId, url, curr));
   });
+
+  it('can parse less strictly', () => {
+  const profile = 'youtube';
+    const profileId = 'gkucmierz';
+
+    const expectedUrl = `https://youtube.com/@${profileId}`;
+    const urlWithExtras = `https://youtube.com/user/${profileId}/videos`;
+
+    expect(lax_sl.sanitize(profile, urlWithExtras)).toBe(expectedUrl);
+  })
 });

--- a/src/profiles/youtube.ts
+++ b/src/profiles/youtube.ts
@@ -5,7 +5,7 @@ export const youtube =  {
   name: 'youtube',
   matches: [
     {
-      match: '(https?://)?(www.)?youtube.com/@?({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
+      match: '(https?://)?(www.)?youtube.com/@({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
       pattern: 'https://youtube.com/@{PROFILE_ID}'
     },
     {


### PR DESCRIPTION
- Added config option for strict with a default value of true. Setting this to false will allow the end of the url to be anything. Useful for YouTube links that are suffixed with /videos

- Updated YouTube regex to require @ instead of letting it be optional. This was incorrectly returning user as the profile id when the url was youtube.com/user/XXXXXXX