### PR TITLE
Added paramater to allow diacritics to links

### DIFF
--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -230,6 +230,23 @@ describe('SocialLinks', () => {
         expect(() => sl.sanitize('linkedin', `gkucmierz${params}`)).toThrowError();
       });
     });
+
+    describe('allowDiactricits', () => {
+      it('should be invalid a link with tilde', () => {
+        sl = new SocialLinks({ allowDiactricits: false });
+        expect(sl.isValid('linkedin', 'https://www.linkedin.com/in/josé-test')).toBeFalsy();
+      })
+
+      it('should be valid a link with tilde', () => {
+        sl = new SocialLinks({ allowDiactricits: true });
+        expect(sl.isValid('linkedin', 'https://www.linkedin.com/in/josé-test')).toBeTruthy();
+      })
+
+      it('should be valid a link with ö', () => {
+        sl = new SocialLinks({ allowDiactricits: true });
+        expect(sl.isValid('linkedin', 'https://www.linkedin.com/in/jösé-test')).toBeTruthy();
+      })
+    })
   });
 
   describe('profiles', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,10 +22,12 @@ export interface Score {
 }
 
 const PROFILE_ID = '[A-Za-z0-9_\\-\\.]+';
+const PROFILE_ID_DIACRITICS = '[Ç-ūA-Za-z0-9_\\-\\.]+';
 const QUERY_PARAM = '(\\?.*)?';
 
 const createRegexp = (profileMatch: ProfileMatch, config: Config): RegExp => {
-  const str = profileMatch.match.replace('{PROFILE_ID}', `${PROFILE_ID}`);
+  const profileId = config.allowDiactricits ? PROFILE_ID_DIACRITICS : PROFILE_ID
+  const str = profileMatch.match.replace('{PROFILE_ID}', `${profileId}`);
   const isTyped = typeof profileMatch.type !== 'undefined';
   const regexp = new RegExp([
     '^', str, ...(config.allowQueryParams && isTyped ? [QUERY_PARAM] : []), '$'
@@ -45,12 +47,14 @@ export interface Config {
   usePredefinedProfiles?: boolean;
   trimInput?: boolean;
   allowQueryParams?: boolean;
+  allowDiactricits?: boolean;
 }
 
 export const DEFAULT_CONFIG: Config = {
   usePredefinedProfiles: true,
   trimInput: true,
   allowQueryParams: false,
+  allowDiactricits: false
 };
 
 export class SocialLinks {


### PR DESCRIPTION
Addressing https://github.com/gkucmierz/social-links/issues/43, added a new configuration option `allowDiactricits`

This option will allow urls with diactrict letters, for instance, áéíóú to be validated by `isValid()` function.

For example:
`https://www.linkedin.com/in/jösé-test` may be a valid Linkedin profile, and not `https://www.linkedin.com/in/jose-test`. So, the first link must be validated by the library.