### PR TITLE
Added support for x (Twitter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "validate",
     "validation",
     "vk",
+    "x",
     "youtube"
   ],
   "author": "Grzegorz Kucmierz",

--- a/src/profiles/index.ts
+++ b/src/profiles/index.ts
@@ -23,7 +23,7 @@ import { substack } from './substack';
 import { telegram } from './telegram';
 import { tiktok } from './tiktok';
 import { twitch } from './twitch';
-import { twitter } from './twitter';
+import { twitter } from './x';
 import { vk } from './vk';
 import { youtube } from './youtube';
 

--- a/src/profiles/x.spec.ts
+++ b/src/profiles/x.spec.ts
@@ -40,11 +40,11 @@ describe('PROFILE: twitter', () => {
     expect(sl.sanitize(profile, desktop, TYPE_DESKTOP)).toBe(desktop);
   };
 
-  it('should linkedin', () => {
-    const profile = 'linkedin';
+  it('should x', () => {
+    const profile = 'x';
     const profileId = 'gkucmierz';
-    const desktop = `https://linkedin.com/in/${profileId}`;
-    const mobile = `https://linkedin.com/mwlite/in/${profileId}`;
+    const desktop = `https://x.com/${profileId}`;
+    const mobile = `https://x.com/${profileId}`;
     testProfile(profile, profileId, desktop, mobile);
   });
 });

--- a/src/profiles/x.ts
+++ b/src/profiles/x.ts
@@ -2,15 +2,19 @@
 import { TYPE_DESKTOP, TYPE_MOBILE } from '../types';
 
 export const twitter = {
-  name: 'twitter',
+  name: 'x',
   matches: [
     {
       match: '(https?://)?(www.)?twitter.com/@?({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
-      pattern: 'https://twitter.com/{PROFILE_ID}'
+      pattern: 'https://x.com/{PROFILE_ID}'
+    },
+    {
+      match: '(https?://)?(www.)?x.com/@?({PROFILE_ID})/?', group: 3, type: TYPE_DESKTOP,
+      pattern: 'https://x.com/{PROFILE_ID}'
     },
     {
       match: '(https?://)?mobile.twitter.com/@?({PROFILE_ID})/?', group: 2, type: TYPE_MOBILE,
-      pattern: 'https://mobile.twitter.com/{PROFILE_ID}'
+      pattern: 'https://x.com/{PROFILE_ID}'
     },
     { match: '@?({PROFILE_ID})', group: 1 },
   ]


### PR DESCRIPTION
Twitter was renamed to X, along with the change in its base domain/URL, and thus, it's necessary to support the new domain - x.com- and keep Twitter.com for backward compatibility.